### PR TITLE
Properly define optional parameters

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -134,8 +134,8 @@ declare namespace SwitchEshop {
     }
 
     export interface RequestOptions {
-        locale: string;
-        limit: number;
+        locale?: string;
+        limit?: number;
         shop: string;
     }
 


### PR DESCRIPTION
Previously TypeScript would break when not defining `locale` and `limit` as it considered them mandatory. That is resolved by adding a `?`

[Source (scroll to Optional Parameters)](https://www.typescriptlang.org/docs/handbook/interfaces.html)