### PR TITLE
Add rollup-plugin-json as country-data loads the data from JSON files

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "rimraf": "^2.6.3",
     "rollup": "^1.18.0",
     "rollup-plugin-commonjs": "^10.0.1",
+    "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-peer-deps-external": "^2.2.0",
     "rollup-plugin-progress": "^1.1.1",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -23,7 +23,11 @@ export default {
     }
   ],
   plugins: [
-    json(),
+    json({
+      preferConst: true,
+      compact: true,
+      namedExports: false,
+    }),
     progress(),
     external(),
     resolve({ preferBuiltins: true }),

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -4,6 +4,7 @@ import external from 'rollup-plugin-peer-deps-external';
 import progress from 'rollup-plugin-progress';
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
+import json from 'rollup-plugin-json';
 
 export default {
   input: 'src/index.ts',
@@ -22,6 +23,7 @@ export default {
     }
   ],
   plugins: [
+    json(),
     progress(),
     external(),
     resolve({ preferBuiltins: true }),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`getShopsByCountryCodes` failed with empty array of `require('country-data').countries.all` on compiled `dist/index.js`

As `country-data` package loads the data from JSON file, `rollup-plugin-json` needs to be added to `rollup`

**Status**
- [x] Code changes have been tested against my own code, or there are no code changes

**Semantic versioning classification:**
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
