### PR TITLE
fix: typing get games america

### DIFF
--- a/packages/nintendo-switch-eshop/src/nintendo-switch-eshop.ts
+++ b/packages/nintendo-switch-eshop/src/nintendo-switch-eshop.ts
@@ -86,7 +86,7 @@ const isStringArray = (array: string | string[]): array is string[] => {
  * @returns {Promise<GameUS[]>} Promise containing all the games
  * @method
  */
-export const getGamesAmerica = async (options: USRequestOptions = {}, offset = 0, games: GameUS[] = []): Promise<any> => {
+export const getGamesAmerica = async (options: USRequestOptions = {}, offset = 0, games: GameUS[] = []): Promise<GameUS[]> => {
   /* eslint-disable */
   const limit = hasProp(options, 'limit') ? options.limit : US_GAME_LIST_LIMIT;
   const shopProp = hasProp(options, 'shop') ? options.shop : 'ncom';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I just changed the typing of the `getGamesAmerica`. The return type was `any` and changed for `GameUS[]`.
Test and Build pass with node 10:latest.

**Status**
- [x] Code changes have been tested against my own code, or there are no code changes

**Semantic versioning classification:**
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
