### PR TITLE
docs: fix typo 'ames' in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ ___
 
 *Defined in [nintendo-switch-eshop.ts:325](https://github.com/lmmfranco/nintendo-switch-eshop/blob/007e160/packages/nintendo-switch-eshop/src/nintendo-switch-eshop.ts#L325)*
 
-Gets pricing information for the requested ames. Paginates every 50 games.
+Gets pricing information for the requested games. Paginates every 50 games.
 
 **Parameters:**
 

--- a/packages/nintendo-switch-eshop/README.md
+++ b/packages/nintendo-switch-eshop/README.md
@@ -420,7 +420,7 @@ ___
 
 *Defined in [nintendo-switch-eshop.ts:325](https://github.com/lmmfranco/nintendo-switch-eshop/blob/007e160/packages/nintendo-switch-eshop/src/nintendo-switch-eshop.ts#L325)*
 
-Gets pricing information for the requested ames. Paginates every 50 games.
+Gets pricing information for the requested games. Paginates every 50 games.
 
 **Parameters:**
 

--- a/packages/nintendo-switch-eshop/src/nintendo-switch-eshop.ts
+++ b/packages/nintendo-switch-eshop/src/nintendo-switch-eshop.ts
@@ -314,7 +314,7 @@ export const getGamesEurope = async (options: EURequestOptions = { limit: EU_GAM
 };
 
 /**
- * Gets pricing information for the requested ames. Paginates every 50 games.
+ * Gets pricing information for the requested games. Paginates every 50 games.
  *
  * @param country A two digit country code. (ISO 3166-1 alpha-2 country code)
  * @param gameIds One or more NSUID of the corresponding games.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7074,10 +7074,10 @@ rollup-plugin-progress@^1.1.1:
   dependencies:
     chalk "^2.4.2"
 
-rollup-plugin-terser@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.1.1.tgz#e9d2545ec8d467f96ba99b9216d2285aad8d5b66"
-  integrity sha512-McIMCDEY8EU6Y839C09UopeRR56wXHGdvKKjlfiZG/GrP6wvZQ62u2ko/Xh1MNH2M9WDL+obAAHySljIZYCuPQ==
+rollup-plugin-terser@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.1.2.tgz#3e41256205cb75f196fc70d4634227d1002c255c"
+  integrity sha512-sWKBCOS+vUkRtHtEiJPAf+WnBqk/C402fBD9AVHxSIXMqjsY7MnYWKYEUqGixtr0c8+1DjzUEPlNgOYQPVrS1g==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     jest-worker "^24.6.0"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Another typo found in the documentation ('ames' => 'games').

**Status**
- [x] Code changes have been tested against my own code, or there are no code changes

**Semantic versioning classification:**
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
